### PR TITLE
Fix double quote issue

### DIFF
--- a/locale/fof-cookie-consent.yml
+++ b/locale/fof-cookie-consent.yml
@@ -13,7 +13,7 @@ fof-cookie-consent:
       theme_popup_title: "Цвета всплывающего окна"
       backgroundColor: "Фон"
       textColor: "Текст"
-      theme_dismiss_title: "Цвет кнопки "Закрыть""
+      theme_dismiss_title: 'Цвет кнопки "Закрыть"'
       buttonBackgroundColor: "Фон"
       buttonTextColor: "Текст"
 


### PR DESCRIPTION
Fixes the following error:

`
Next Symfony\Component\Translation\Exception\InvalidResourceException: The file "/app/public/../vendor/composer/../marketplace/flarum-l10n-ext-russian/locale/fof-cookie-consent.yml" does not contain valid YAML: Unexpected characters near "Закрыть"" at line 16 (near "theme_dismiss_title: "Цвет кнопки "Закрыть""). in /app/vendor/symfony/translation/Loader/YamlFileLoader.php:45
`

This error will cause the forum to not load entirely (error 500).

Ref: https://discuss.flarum.org/d/7585/1891